### PR TITLE
Rule set table schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # AiTravelAssistant
+
+## Database schema
+
+### `decision_unit`
+- `id` (PK)
+- `rule_set_ids` (varchar(256))：多个 `rule_set_id` 用 `,` 隔开
+- `app_name`
+
+### `rule_set`
+- `rule_set_id` (PK)
+- `meta` (varchar(5120))
+- `rules_order`
+
+DDL: see `db/schema.sql`.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,26 @@
+-- Database schema for AiTravelAssistant
+-- Notes:
+-- - `decision_unit.rule_set_ids` stores multiple rule_set_id values separated by commas, per requirement.
+-- - Prefer a join table for normalization if/when possible.
+
+-- MySQL 8+ recommended
+
+CREATE TABLE IF NOT EXISTS `rule_set` (
+  `rule_set_id` VARCHAR(64) NOT NULL,
+  `meta` VARCHAR(5120) NULL,
+  `rules_order` VARCHAR(1024) NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`rule_set_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS `decision_unit` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `rule_set_ids` VARCHAR(256) NOT NULL,
+  `app_name` VARCHAR(128) NOT NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_decision_unit_app_name` (`app_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+


### PR DESCRIPTION
Add initial MySQL DDL for `decision_unit` and `rule_set` tables to define the required database schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-986513aa-8782-4c5e-be65-b561b40c0cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-986513aa-8782-4c5e-be65-b561b40c0cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

